### PR TITLE
tests: extending norewites test with another example

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "debug": "^4.1.1",
     "packherd": "^0.9.0",
     "resolve-from": "^5.0.0",
-    "snapbuild": "^0.0.130",
+    "snapbuild": "^0.0.132",
     "source-map-js": "^0.6.2",
     "supports-color": "^8.1.1",
     "terser": "^5.3.2",

--- a/src/tests/doctor/fixtures/no-rewrite/app.js
+++ b/src/tests/doctor/fixtures/no-rewrite/app.js
@@ -3,6 +3,6 @@
 
 const fs = require('fs')
 
-const patch = require('./entry')
+const { patch, supportsColor } = require('./entry')
 patch()
-console.log(JSON.stringify({ patchedCwd: fs.patchedCwd }))
+console.log(JSON.stringify({ patchedCwd: fs.patchedCwd, supportsColorStdout: supportsColor.stdout }))

--- a/src/tests/doctor/fixtures/no-rewrite/entry.js
+++ b/src/tests/doctor/fixtures/no-rewrite/entry.js
@@ -4,6 +4,7 @@
 const fs = require('fs')
 const patch = require('./graceful-fs-polyfill')
 
-module.exports = function patchFs() {
+exports.patch = function patchFs() {
   patch(fs)
 }
+exports.supportsColor = require('./lib/colors/lib/system/supports-colors')

--- a/src/tests/doctor/fixtures/no-rewrite/lib/colors/lib/system/has-flag.js
+++ b/src/tests/doctor/fixtures/no-rewrite/lib/colors/lib/system/has-flag.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function(flag, argv) {
+  argv = argv || process.argv;
+
+  var terminatorPos = argv.indexOf('--');
+  var prefix = /^-{1,2}/.test(flag) ? '' : '--';
+  var pos = argv.indexOf(prefix + flag);
+
+  return pos !== -1 && (terminatorPos === -1 ? true : pos < terminatorPos);
+};

--- a/src/tests/doctor/fixtures/no-rewrite/lib/colors/lib/system/supports-colors.js
+++ b/src/tests/doctor/fixtures/no-rewrite/lib/colors/lib/system/supports-colors.js
@@ -1,0 +1,129 @@
+'use strict';
+
+// Full repro of supports color module which causes norewrite and is problematic on windows.
+// We also nest it deep inside node_modules in order to mirror the encountered issue
+
+var os = require('os');
+var hasFlag = require('./has-flag.js');
+
+var env = process.env;
+
+var forceColor = void 0;
+if (hasFlag('no-color') || hasFlag('no-colors') || hasFlag('color=false')) {
+  forceColor = false;
+} else if (hasFlag('color') || hasFlag('colors') || hasFlag('color=true')
+           || hasFlag('color=always')) {
+  forceColor = true;
+}
+if ('FORCE_COLOR' in env) {
+  forceColor = env.FORCE_COLOR.length === 0
+    || parseInt(env.FORCE_COLOR, 10) !== 0;
+}
+
+function translateLevel(level) {
+  if (level === 0) {
+    return false;
+  }
+
+  return {
+    level: level,
+    hasBasic: true,
+    has256: level >= 2,
+    has16m: level >= 3,
+  };
+}
+
+function supportsColor(stream) {
+  if (forceColor === false) {
+    return 0;
+  }
+
+  if (hasFlag('color=16m') || hasFlag('color=full')
+      || hasFlag('color=truecolor')) {
+    return 3;
+  }
+
+  if (hasFlag('color=256')) {
+    return 2;
+  }
+
+  if (stream && !stream.isTTY && forceColor !== true) {
+    return 0;
+  }
+
+  var min = forceColor ? 1 : 0;
+
+  if (process.platform === 'win32') {
+    // Node.js 7.5.0 is the first version of Node.js to include a patch to
+    // libuv that enables 256 color output on Windows. Anything earlier and it
+    // won't work. However, here we target Node.js 8 at minimum as it is an LTS
+    // release, and Node.js 7 is not. Windows 10 build 10586 is the first
+    // Windows release that supports 256 colors. Windows 10 build 14931 is the
+    // first release that supports 16m/TrueColor.
+    var osRelease = os.release().split('.');
+    if (Number(process.versions.node.split('.')[0]) >= 8
+        && Number(osRelease[0]) >= 10 && Number(osRelease[2]) >= 10586) {
+      return Number(osRelease[2]) >= 14931 ? 3 : 2;
+    }
+
+    return 1;
+  }
+
+  if ('CI' in env) {
+    if (['TRAVIS', 'CIRCLECI', 'APPVEYOR', 'GITLAB_CI'].some(function(sign) {
+      return sign in env;
+    }) || env.CI_NAME === 'codeship') {
+      return 1;
+    }
+
+    return min;
+  }
+
+  if ('TEAMCITY_VERSION' in env) {
+    return (/^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0
+    );
+  }
+
+  if ('TERM_PROGRAM' in env) {
+    var version = parseInt((env.TERM_PROGRAM_VERSION || '').split('.')[0], 10);
+
+    switch (env.TERM_PROGRAM) {
+      case 'iTerm.app':
+        return version >= 3 ? 3 : 2;
+      case 'Hyper':
+        return 3;
+      case 'Apple_Terminal':
+        return 2;
+      // No default
+    }
+  }
+
+  if (/-256(color)?$/i.test(env.TERM)) {
+    return 2;
+  }
+
+  if (/^screen|^xterm|^vt100|^rxvt|color|ansi|cygwin|linux/i.test(env.TERM)) {
+    return 1;
+  }
+
+  if ('COLORTERM' in env) {
+    return 1;
+  }
+
+  if (env.TERM === 'dumb') {
+    return min;
+  }
+
+  return min;
+}
+
+function getSupportLevel(stream) {
+  var level = supportsColor(stream);
+  return translateLevel(level);
+}
+
+module.exports = {
+  supportsColor: getSupportLevel,
+  stdout: getSupportLevel(process.stdout),
+  stderr: getSupportLevel(process.stderr),
+};

--- a/src/tests/doctor/no-rewrite.test.ts
+++ b/src/tests/doctor/no-rewrite.test.ts
@@ -38,6 +38,7 @@ test('doctor: entry requires a module that has is detected norewrite', async (t)
   try {
     ;({ stdout, stderr } = await exec(cmd, { env }))
     const res = JSON.parse(stdout.trim())
+    console.log(res)
     t.equal(res.patchedCwd, process.cwd())
   } catch (err: any) {
     console.log(stdout)


### PR DESCRIPTION
- supports-color caused issues on windows so we'll use this test to
  triage it
